### PR TITLE
Fix uncentered body

### DIFF
--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -49,7 +49,7 @@ body {
   position: relative;
   height: 100%;
   max-height: 100%;
-  width: 100vw;
+  width: 100%;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
`vw` includes the scrollbar's width, so it'd only work properly on pages without a vertical scrollbar. Kind of like what hackclub/hackathons#20 fixed.